### PR TITLE
Add error handling tests

### DIFF
--- a/helpers/mathparser/calculator_err.go
+++ b/helpers/mathparser/calculator_err.go
@@ -1,0 +1,65 @@
+package mathparser
+
+import "fmt"
+
+// CalcErrorType represents different error categories for the calculator.
+type CalcErrorType int
+
+const (
+	// ErrorInvalidNumber indicates a number could not be parsed.
+	ErrorInvalidNumber CalcErrorType = iota
+	// ErrorUnknownCharacter is returned for an unrecognized rune in the input.
+	ErrorUnknownCharacter
+	// ErrorMismatchedParentheses indicates parentheses balance issues during parsing.
+	ErrorMismatchedParentheses
+	// ErrorUnexpectedToken covers situations where a token is not valid in context.
+	ErrorUnexpectedToken
+	// ErrorStackUnderflow occurs when evaluation pops from an empty stack.
+	ErrorStackUnderflow
+	// ErrorUnknownIdentifier denotes an identifier that isn't recognised.
+	ErrorUnknownIdentifier
+	// ErrorDivisionByZero is returned when attempting to divide by zero.
+	ErrorDivisionByZero
+	// ErrorInfiniteResult covers infinite or NaN results from floating ops.
+	ErrorInfiniteResult
+	// ErrorResultTooBig indicates a computed value would overflow practical limits.
+	ErrorResultTooBig
+	// ErrorInvalidExpression reports general expression validity failures.
+	ErrorInvalidExpression
+	// ErrorModuloRequiresInt when modulo is used with non-integers.
+	ErrorModuloRequiresInt
+	// ErrorModByZero for modulo by zero.
+	ErrorModByZero
+	// ErrorPermutationRequiresInt when permutation inputs are not integers.
+	ErrorPermutationRequiresInt
+	// ErrorInvalidPermutation when permutation parameters are out of bounds.
+	ErrorInvalidPermutation
+	// ErrorCombinationRequiresInt when combination inputs are not integers.
+	ErrorCombinationRequiresInt
+	// ErrorInvalidCombination when combination parameters are out of bounds.
+	ErrorInvalidCombination
+	// ErrorFactorialRequiresInt when factorial operand is not integer.
+	ErrorFactorialRequiresInt
+	// ErrorFactorialNegative when factorial operand is negative.
+	ErrorFactorialNegative
+)
+
+// CalcError wraps an error with additional context such as the position in the input.
+type CalcError struct {
+	Typ CalcErrorType
+	msg string
+	pos int
+}
+
+// errorAt formats an error message and returns a CalcError with the given type and position.
+func errorAt(pos int, typ CalcErrorType, format string, args ...interface{}) *CalcError {
+	return &CalcError{
+		Typ: typ,
+		pos: pos,
+		msg: fmt.Sprintf(format, args...),
+	}
+}
+
+func (e *CalcError) Error() string {
+	return e.msg
+}

--- a/helpers/mathparser/new_calculator_test.go
+++ b/helpers/mathparser/new_calculator_test.go
@@ -123,3 +123,49 @@ func TestEvaluate(t *testing.T) {
 	as.NoError(err)
 	as.Equal(big.NewRat(720, 1), res)
 }
+
+func TestTokenizeErrors(t *testing.T) {
+	as := require.New(t)
+
+	_, err := tokenize("1.2.3")
+	as.Error(err)
+	ce, ok := err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorInvalidNumber, ce.Typ)
+	as.Equal(0, ce.pos)
+
+	_, err = tokenize("1$2")
+	as.Error(err)
+	ce, ok = err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorUnknownCharacter, ce.Typ)
+	as.Equal(1, ce.pos)
+}
+
+func TestEvaluateErrors(t *testing.T) {
+	as := require.New(t)
+
+	_, err := Evaluate("1+(2")
+	as.Error(err)
+	ce, ok := err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorMismatchedParentheses, ce.Typ)
+
+	_, err = Evaluate("foo")
+	as.Error(err)
+	ce, ok = err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorUnknownIdentifier, ce.Typ)
+
+	_, err = Evaluate("1/0")
+	as.Error(err)
+	ce, ok = err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorDivisionByZero, ce.Typ)
+
+	_, err = Evaluate("1.1 % 2")
+	as.Error(err)
+	ce, ok = err.(*CalcError)
+	as.True(ok)
+	as.Equal(ErrorModuloRequiresInt, ce.Typ)
+}


### PR DESCRIPTION
## Summary
- add failing input coverage to calculator tests

## Testing
- `cd helpers/mathparser && go test`

------
https://chatgpt.com/codex/tasks/task_e_684ae6b105d0832d8abe16ebeb532439