### PR TITLE
Add Telegram-like search results component

### DIFF
--- a/http/frontend/package-lock.json
+++ b/http/frontend/package-lock.json
@@ -8,13 +8,13 @@
       "name": "ytyango-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@types/telegram-web-app": "^9.1.0",
         "openapi-fetch": "^0.15.0",
         "vue": "^3.4.38",
         "vue-router": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.7.4",
+        "@types/telegram-web-app": "^9.1.0",
         "@vitejs/plugin-vue": "^6.0.2",
         "openapi-typescript": "^7.10.1",
         "typescript": "^5.6.2",
@@ -214,7 +214,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -258,7 +257,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1141,7 +1139,6 @@
       "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1150,6 +1147,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@types/telegram-web-app/-/telegram-web-app-9.1.0.tgz",
       "integrity": "sha512-DnDoFTNaKkO7k3QqKD+LBCVTThSbq4rTz/IKBJ9MGWBmjIHpiCrKNAYebRB6cQe76PPTzcbVZA6QZP1WKqyKHQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@unhead/dom": {
@@ -2144,7 +2142,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2338,7 +2335,6 @@
       "integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -2448,7 +2444,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2470,7 +2465,6 @@
       "integrity": "sha512-gEEjkV11Aj+rBnY6wnRfsFtF2RxKOLaPN4i+Gx3UhBxnszvV6ApSNZbGk7WKyy/lErQ6ekPN63qdFL7sa1leow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "hookable": "^5.5.3"
       },
@@ -2484,7 +2478,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -2609,7 +2602,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",
@@ -2631,7 +2623,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.3.tgz",
       "integrity": "sha512-ARBedLm9YlbvQomnmq91Os7ck6efydTSpRP3nuOKCvgJOHNrhRoJDSKtee8kcL1Vf7nz6U+PMBL+hTvR3bTVQg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },

--- a/http/frontend/src/components/MessageSearchResults.vue
+++ b/http/frontend/src/components/MessageSearchResults.vue
@@ -1,0 +1,91 @@
+<template>
+  <section class="message-results">
+    <header class="results-header">
+      <div>
+        <p class="eyebrow">搜索结果</p>
+        <h3>找到 {{ result.estimatedTotalHits }} 条消息</h3>
+        <p class="muted">耗时 {{ result.processingTimeMs }} ms</p>
+      </div>
+      <div class="result-summary" v-if="query">
+        <span class="summary-label">关键词</span>
+        <span class="summary-value">{{ query }}</span>
+      </div>
+    </header>
+
+    <div v-if="result.hits.length === 0" class="empty-hint">没有匹配的消息。</div>
+    <div v-else class="result-list">
+      <article v-for="hit in result.hits" :key="hit.mongo_id" class="result-row">
+        <div class="avatar" :style="{ backgroundColor: avatarColor(hit.from_id) }">
+          <span>{{ avatarInitial(hit) }}</span>
+        </div>
+        <div class="result-content">
+          <div class="result-top">
+            <div class="user-meta">
+              <span class="user-name">{{ displayName(hit) }}</span>
+              <span class="user-id">ID: {{ hit.from_id }}</span>
+            </div>
+            <div class="message-meta">
+              <span class="message-id">#{{ hit.msg_id }}</span>
+              <span class="message-time">{{ formatDate(hit.date) }}</span>
+            </div>
+          </div>
+          <p class="message-text">{{ messagePreview(hit) }}</p>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import type { MeiliMsg, SearchResult } from '../services/api'
+
+defineProps<{
+  result: SearchResult
+  query?: string
+}>()
+
+const colorPalette = [
+  '#5E81F4',
+  '#7C3AED',
+  '#10B981',
+  '#F59E0B',
+  '#EF4444',
+  '#14B8A6',
+  '#F472B6',
+  '#3B82F6',
+  '#8B5CF6',
+  '#6366F1',
+]
+
+function avatarColor(userId: number) {
+  const idString = String(userId)
+  let hash = 0
+  for (let i = 0; i < idString.length; i += 1) {
+    hash = (hash << 5) - hash + idString.charCodeAt(i)
+    hash |= 0
+  }
+  const index = Math.abs(hash) % colorPalette.length
+  return colorPalette[index]
+}
+
+function displayName(hit: MeiliMsg) {
+  if ((hit as Record<string, unknown>).from_name) {
+    return String((hit as Record<string, unknown>).from_name)
+  }
+  return `用户 ${hit.from_id}`
+}
+
+function avatarInitial(hit: MeiliMsg) {
+  const name = displayName(hit).trim()
+  return name.charAt(0).toUpperCase() || '#'
+}
+
+function messagePreview(hit: MeiliMsg) {
+  return hit.message || hit.image_text || hit.qr_result || '无正文'
+}
+
+function formatDate(timestamp: number) {
+  const date = new Date(timestamp * 1000)
+  return date.toLocaleString()
+}
+</script>

--- a/http/frontend/src/pages/HomePage.vue
+++ b/http/frontend/src/pages/HomePage.vue
@@ -89,26 +89,14 @@
       </div>
     </div>
 
-    <div v-if="searchResult" class="panel" style="margin-top: 16px; padding: 12px">
-      <h3>搜索结果（{{ searchResult.estimatedTotalHits }} 条，耗时 {{ searchResult.processingTimeMs }} ms）</h3>
-      <div v-if="searchResult.hits.length === 0" class="muted">没有匹配的消息。</div>
-      <div v-else class="results">
-        <article v-for="hit in searchResult.hits" :key="hit.mongo_id" class="result-card">
-          <div class="result-meta">
-            <span>用户: {{ hit.from_id }}</span>
-            <span>消息ID: {{ hit.msg_id }}</span>
-            <span>时间: {{ formatDate(hit.date) }}</span>
-          </div>
-          <p class="result-message">{{ hit.message || hit.image_text || hit.qr_result || '无正文' }}</p>
-        </article>
-      </div>
-    </div>
+    <MessageSearchResults v-if="searchResult" :result="searchResult" :query="query" />
   </section>
 </template>
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
 import { fetchGroupStat, ping, searchMessages, type ChatStat, type SearchResult } from '../services/api'
+import MessageSearchResults from '../components/MessageSearchResults.vue'
 import { useTelegram } from '../services/telegram'
 const telegram = useTelegram()
 const groupWebId = ref<number | null>(null)
@@ -175,10 +163,5 @@ async function performSearch() {
   } finally {
     loadingSearch.value = false
   }
-}
-
-function formatDate(timestamp: number) {
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleString()
 }
 </script>

--- a/http/frontend/src/style.css
+++ b/http/frontend/src/style.css
@@ -199,6 +199,136 @@ button:disabled {
   margin-top: 6px;
 }
 
+.message-results {
+  margin-top: 16px;
+  padding: 16px;
+  background: var(--tg-bg-secondary);
+  border: 1px solid var(--tg-border);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.04);
+}
+
+.results-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.result-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--tg-link) 10%, transparent);
+  color: var(--tg-text);
+}
+
+.summary-label {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+}
+
+.summary-value {
+  font-weight: 700;
+}
+
+.result-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.result-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--tg-border);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--tg-bg-secondary) 80%, var(--tg-bg) 20%);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.04);
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  color: #fff;
+  text-transform: uppercase;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
+  flex-shrink: 0;
+}
+
+.result-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.result-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.user-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.user-name {
+  font-weight: 800;
+  color: var(--tg-text);
+}
+
+.user-id {
+  color: var(--tg-hint);
+  font-size: 13px;
+}
+
+.message-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  color: var(--tg-hint);
+  font-size: 13px;
+}
+
+.message-id {
+  font-weight: 700;
+  color: var(--tg-link);
+}
+
+.message-time {
+  white-space: nowrap;
+}
+
+.message-text {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.empty-hint {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--tg-bg) 70%, var(--tg-bg-secondary) 30%);
+  color: var(--tg-hint);
+}
+
 .alert {
   padding: 12px;
   border-radius: 10px;
@@ -235,29 +365,6 @@ button:disabled {
 .panel {
     min-width: 0; /* 允许被压缩，不会撑爆 */
 }
-.results {
-  display: grid;
-  gap: 12px;
-}
 .app-shell {
     min-width: 0;
-}
-.result-card {
-  border: 1px solid var(--tg-border);
-  border-radius: 10px;
-  padding: 12px;
-  background: var(--tg-bg-secondary);
-}
-
-.result-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  color: var(--tg-hint);
-  font-size: 13px;
-}
-
-.result-message {
-  margin: 8px 0 0;
-  white-space: pre-wrap;
 }


### PR DESCRIPTION
## Summary
- add a MessageSearchResults component that renders hits with Telegram-style dialog visuals and deterministic avatar colors
- update the home page search section to reuse the new component and show query metadata
- refresh global styles to support the new layout and avatar presentation

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927b089d1f4832d8506f96cd26f91bd)